### PR TITLE
Change prompt style to avoid breaklines

### DIFF
--- a/multimodalmaestro/lmms/gpt4.py
+++ b/multimodalmaestro/lmms/gpt4.py
@@ -4,12 +4,12 @@ import cv2
 import numpy as np
 import requests
 
-META_PROMPT = '''
-For any labels or markings on an image that you reference in your response, please 
-enclose them in square brackets ([]) and list them explicitly. Do not use ranges; for 
-example, instead of '1 - 4', list as '[1], [2], [3], [4]'. These labels could be 
-numbers or letters and typically correspond to specific segments or parts of the image.
-'''
+META_PROMPT = (
+    "For any labels or markings on an image that you reference in your response, please "
+    "enclose them in square brackets ([]) and list them explicitly. Do not use ranges; for "
+    "example, instead of '1 - 4', list as '[1], [2], [3], [4]'. These labels could be "
+    "numbers or letters and typically correspond to specific segments or parts of the image."
+)
 
 API_URL = "https://api.openai.com/v1/chat/completions"
 


### PR DESCRIPTION
# Description

When using triple quotes for multiline strings it generates \n at the end of each line. In order to avoid any issues related to the prompt, I suggest the proposed change.

Below you can see the system prompt we are sending to GPT4.

```json
{'role': 'system', 'content': ["\nFor any labels or markings on an image that you reference in your response, please \nenclose them in square brackets ([]) and list them explicitly. Do not use ranges; for \nexample, instead of '1 - 4', list as '[1], [2], [3], [4]'. These labels could be \nnumbers or letters and typically correspond to specific segments or parts of the image.\n"]}
```

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
