### PR TITLE
fix: current Florence-2 training pipeline is missing `timm`

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,3 +7,4 @@ sentencepiece~=0.2.0
 peft~=0.12.0
 flash-attn~=2.6.3
 einops~=0.8.0
+timm~=1.0.9


### PR DESCRIPTION
# Description

Add `timm` dependency required by Florence-2
