### PR TITLE
fix: Florence-2 recipe fails during mAP calculation

### DIFF
--- a/maestro/trainer/models/florence_2/metrics.py
+++ b/maestro/trainer/models/florence_2/metrics.py
@@ -28,6 +28,8 @@ def postprocess_florence2_output_for_mean_average_precision(
         # Postprocess prediction for mean average precision calculation
         prediction = processor.post_process_generation(generated_text, task="<OD>", image_size=image.size)
         prediction = sv.Detections.from_lmm(sv.LMM.FLORENCE_2, prediction, resolution_wh=image.size)
+        if len(prediction) == 0:
+            prediction["class_name"] = []
         prediction = prediction[np.isin(prediction["class_name"], classes)]
         prediction.class_id = np.array([classes.index(class_name) for class_name in prediction["class_name"]])
         # Set confidence for mean average precision calculation
@@ -35,6 +37,8 @@ def postprocess_florence2_output_for_mean_average_precision(
         
         # Postprocess target for mean average precision calculation
         target = processor.post_process_generation(suffix, task="<OD>", image_size=image.size)
+        if len(target) == 0:
+            target["class_name"] = []
         target = sv.Detections.from_lmm(sv.LMM.FLORENCE_2, target, resolution_wh=image.size)
         target.class_id = np.array([classes.index(class_name) for class_name in target["class_name"]])
         


### PR DESCRIPTION
# Description

fix: Florence-2 recipe fails during mAP calculation

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
