### PR TITLE
Add quotes to pip install command so it is Mac zsh compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To begin, install the model-specific dependencies. Since some models may have cl
 we recommend creating a dedicated Python environment for each model.
 
 ```bash
-pip install maestro[paligemma_2]
+pip install "maestro[paligemma_2]"
 ```
 
 ### CLI

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,19 +49,19 @@ we recommend creating a dedicated Python environment for each model.
 === "Florence-2"
 
     ```bash
-    pip install maestro[florence_2]
+    pip install "maestro[florence_2]"
     ```
 
 === "PaliGemma 2"
 
     ```bash
-    pip install maestro[paligemma_2]
+    pip install "maestro[paligemma_2]"
     ```
 
 === "Qwen2.5-VL"
 
     ```bash
-    pip install maestro[qwen_2_5_vl]
+    pip install "maestro[qwen_2_5_vl]"
     pip install git+https://github.com/huggingface/transformers
     ```
 

--- a/docs/models/florence_2.md
+++ b/docs/models/florence_2.md
@@ -5,7 +5,7 @@ Florence-2 is a lightweight vision-language model open-sourced by Microsoft unde
 ## Install
 
 ```bash
-pip install maestro[florence_2]
+pip install "maestro[florence_2]"
 ```
 
 ## Train

--- a/docs/models/paligemma_2.md
+++ b/docs/models/paligemma_2.md
@@ -5,7 +5,7 @@ PaliGemma 2 is an updated and significantly enhanced version of the original Pal
 ## Install
 
 ```bash
-pip install maestro[paligemma_2]
+pip install "maestro[paligemma_2]"
 ```
 
 ## Train

--- a/docs/models/qwen_2_5_vl.md
+++ b/docs/models/qwen_2_5_vl.md
@@ -7,8 +7,8 @@ Building on significant improvements over its predecessor, Qwen2-VL, the Qwen2.5
 ## Install
 
 ```bash
-pip install maestro[qwen_2_5_vl]
-pip install git+https://github.com/huggingface/transformers
+pip install "maestro[qwen_2_5_vl]"
+pip install "git+https://github.com/huggingface/transformers"
 ```
 
 !!! warning


### PR DESCRIPTION
# Description
pip instruction not recognised by zsh as of the square bracket
(issue)[https://github.com/roboflow/maestro/issues/142]

## Type of change
adding double quotes to the package name

## How has this change been tested, please provide a testcase or example of how you tested the change?
tested in my zsh