### PR TITLE
Device map feature for maestro models -qwen_2.5, florence_2 & paligemma_2

### DIFF
--- a/maestro/trainer/models/florence_2/checkpoints.py
+++ b/maestro/trainer/models/florence_2/checkpoints.py
@@ -1,8 +1,7 @@
 import os
 from enum import Enum
-from typing import Optional, Union
+from typing import Optional
 
-import torch
 from peft import LoraConfig, get_peft_model
 from transformers import AutoModelForCausalLM, AutoProcessor
 
@@ -32,7 +31,7 @@ def load_model(
     Args:
         model_id_or_path (str): The identifier or path of the Florence 2 model to load.
         revision (str): The specific model revision to use.
-        device_map (Optional[Union[str, dict]]): Device map for the model:        
+        device_map (Optional[Union[str, dict]]): Device map for the model:
             -"auto": Places model on single available device (default)
             - String like "cpu", "cuda:0", or "mps" for a specific device
             - Note: Florence-2 doesn't support dict mapping
@@ -47,7 +46,7 @@ def load_model(
         ValueError: If the model or processor cannot be loaded.
     """
 
-    device = parse_device_spec(device_map) 
+    device = parse_device_spec(device_map)
     processor = AutoProcessor.from_pretrained(model_id_or_path, trust_remote_code=True, revision=revision)
 
     if optimization_strategy == OptimizationStrategy.LORA:

--- a/maestro/trainer/models/florence_2/checkpoints.py
+++ b/maestro/trainer/models/florence_2/checkpoints.py
@@ -1,6 +1,6 @@
 import os
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 from peft import LoraConfig, get_peft_model
@@ -23,7 +23,7 @@ class OptimizationStrategy(Enum):
 def load_model(
     model_id_or_path: str = DEFAULT_FLORENCE2_MODEL_ID,
     revision: str = DEFAULT_FLORENCE2_MODEL_REVISION,
-    device: str | torch.device = "auto",
+    device_map: Optional[str] = "auto",
     optimization_strategy: OptimizationStrategy = OptimizationStrategy.NONE,
     cache_dir: Optional[str] = None,
 ) -> tuple[AutoProcessor, AutoModelForCausalLM]:
@@ -32,7 +32,10 @@ def load_model(
     Args:
         model_id_or_path (str): The identifier or path of the Florence 2 model to load.
         revision (str): The specific model revision to use.
-        device (torch.device): The device to load the model onto.
+        device_map (Optional[Union[str, dict]]): Device map for the model:        
+            -"auto": Places model on single available device (default)
+            - String like "cpu", "cuda:0", or "mps" for a specific device
+            - Note: Florence-2 doesn't support dict mapping
         optimization_strategy (OptimizationStrategy): The optimization strategy to apply to the model.
         cache_dir (Optional[str]): Directory to cache the downloaded model files.
 
@@ -43,7 +46,8 @@ def load_model(
     Raises:
         ValueError: If the model or processor cannot be loaded.
     """
-    device = parse_device_spec(device)
+
+    device = parse_device_spec(device_map) 
     processor = AutoProcessor.from_pretrained(model_id_or_path, trust_remote_code=True, revision=revision)
 
     if optimization_strategy == OptimizationStrategy.LORA:

--- a/maestro/trainer/models/paligemma_2/checkpoints.py
+++ b/maestro/trainer/models/paligemma_2/checkpoints.py
@@ -6,8 +6,6 @@ import torch
 from peft import LoraConfig, get_peft_model
 from transformers import BitsAndBytesConfig, PaliGemmaForConditionalGeneration, PaliGemmaProcessor
 
-from maestro.trainer.common.utils.device import parse_device_spec
-
 DEFAULT_PALIGEMMA2_MODEL_ID = "google/paligemma2-3b-pt-224"
 DEFAULT_PALIGEMMA2_MODEL_REVISION = "refs/heads/main"
 

--- a/maestro/trainer/models/paligemma_2/checkpoints.py
+++ b/maestro/trainer/models/paligemma_2/checkpoints.py
@@ -1,6 +1,6 @@
 import os
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 from peft import LoraConfig, get_peft_model
@@ -24,7 +24,7 @@ class OptimizationStrategy(Enum):
 def load_model(
     model_id_or_path: str = DEFAULT_PALIGEMMA2_MODEL_ID,
     revision: str = DEFAULT_PALIGEMMA2_MODEL_REVISION,
-    device: str | torch.device = "auto",
+    device_map: Optional[Union[str, dict]] = None,
     optimization_strategy: OptimizationStrategy = OptimizationStrategy.NONE,
     cache_dir: Optional[str] = None,
 ) -> tuple[PaliGemmaProcessor, PaliGemmaForConditionalGeneration]:
@@ -33,7 +33,10 @@ def load_model(
     Args:
         model_id_or_path (str): The identifier or path of the model to load.
         revision (str): The specific model revision to use.
-        device (torch.device): The device to load the model onto.
+        device_map (Optional[Union[str, dict]]): Device map for the model:
+            - None: Uses "auto" for automatic distribution across available devices (default)
+            - String like "cpu", "cuda:0", or "mps" for a specific device
+            - Dict for custom module-to-device mapping (e.g., {"": "cuda:0"})
         optimization_strategy (OptimizationStrategy): The optimization strategy to apply to the model.
         cache_dir (Optional[str]): Directory to cache the downloaded model files.
 
@@ -44,7 +47,6 @@ def load_model(
     Raises:
         ValueError: If the model or processor cannot be loaded.
     """
-    device = parse_device_spec(device)
     processor = PaliGemmaProcessor.from_pretrained(model_id_or_path, trust_remote_code=True, revision=revision)
 
     if optimization_strategy in {OptimizationStrategy.LORA, OptimizationStrategy.QLORA}:
@@ -66,7 +68,7 @@ def load_model(
             pretrained_model_name_or_path=model_id_or_path,
             revision=revision,
             trust_remote_code=True,
-            device_map="auto",
+            device_map=device_map if device_map else "auto",
             quantization_config=bnb_config,
             torch_dtype=torch.bfloat16,
             cache_dir=cache_dir,
@@ -78,9 +80,9 @@ def load_model(
             pretrained_model_name_or_path=model_id_or_path,
             revision=revision,
             trust_remote_code=True,
-            device_map="auto",
+            device_map=device_map if device_map else "auto",
             cache_dir=cache_dir,
-        ).to(device)
+        )
 
         if optimization_strategy == OptimizationStrategy.FREEZE:
             for param in model.vision_tower.parameters():

--- a/maestro/trainer/models/qwen_2_5_vl/checkpoints.py
+++ b/maestro/trainer/models/qwen_2_5_vl/checkpoints.py
@@ -1,6 +1,6 @@
 import os
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 from peft import LoraConfig, get_peft_model
@@ -23,7 +23,7 @@ class OptimizationStrategy(Enum):
 def load_model(
     model_id_or_path: str = DEFAULT_QWEN2_5_VL_MODEL_ID,
     revision: str = DEFAULT_QWEN2_5_VL_MODEL_REVISION,
-    device: str | torch.device = "auto",
+    device_map: Optional[Union[str, dict]] = None,
     optimization_strategy: OptimizationStrategy = OptimizationStrategy.NONE,
     cache_dir: Optional[str] = None,
     min_pixels: int = 256 * 28 * 28,
@@ -35,7 +35,10 @@ def load_model(
     Args:
         model_id_or_path (str): The model name or path.
         revision (str): The model revision to load.
-        device (str | torch.device): The device to load the model onto.
+        device_map (Optional[Union[str, dict]]): Device map for the model:
+            - None: Uses "auto" for automatic distribution across available devices (default)
+            - String like "cpu", "cuda:0", or "mps" for a specific device
+            - Dict for custom module-to-device mapping (e.g., {"": "cuda:0"})
         optimization_strategy (OptimizationStrategy): LORA, QLORA, or NONE.
         cache_dir (Optional[str]): Directory to cache downloaded model files.
         min_pixels (int): Minimum number of pixels allowed in the resized image.
@@ -45,7 +48,6 @@ def load_model(
         (Qwen2_5_VLProcessor, Qwen2_5_VLForConditionalGeneration):
             A tuple containing the loaded processor and model.
     """
-    device = parse_device_spec(device)
     processor = Qwen2_5_VLProcessor.from_pretrained(
         model_id_or_path,
         revision=revision,
@@ -82,7 +84,7 @@ def load_model(
             model_id_or_path,
             revision=revision,
             trust_remote_code=True,
-            device_map="auto",
+            device_map=device_map if device_map else "auto",
             quantization_config=bnb_config,
             torch_dtype=torch.bfloat16,
             cache_dir=cache_dir,
@@ -94,11 +96,10 @@ def load_model(
             model_id_or_path,
             revision=revision,
             trust_remote_code=True,
-            device_map="auto",
+            device_map=device_map if device_map else "auto",
             torch_dtype=torch.bfloat16,
             cache_dir=cache_dir,
         )
-        model.to(device)
 
     return processor, model
 

--- a/maestro/trainer/models/qwen_2_5_vl/checkpoints.py
+++ b/maestro/trainer/models/qwen_2_5_vl/checkpoints.py
@@ -6,8 +6,6 @@ import torch
 from peft import LoraConfig, get_peft_model
 from transformers import BitsAndBytesConfig, Qwen2_5_VLForConditionalGeneration, Qwen2_5_VLProcessor
 
-from maestro.trainer.common.utils.device import parse_device_spec
-
 DEFAULT_QWEN2_5_VL_MODEL_ID = "Qwen/Qwen2.5-VL-3B-Instruct"
 DEFAULT_QWEN2_5_VL_MODEL_REVISION = "refs/heads/main"
 


### PR DESCRIPTION



# Description

As discussed in this issue [https://github.com/roboflow/maestro/issues/176](url), this PR implements the device map feature for loading all 3 models. No change in dependencies is required. 

The 'device' hyperparameter was replaced by 'device map' to maintain consistency with huggingface and avoid confusion.  It was also ensured in the Florence 2 model that the device map does not take in a dict input, eg: {"": "cuda:0"}   and 'auto' directly assigns the device to an available device based on the already existing parse_device_spec() function.

For Qwen 2.5 and PaliGemma 2, the device map is directly passed to the loading of the models (from_pretrained), with the default set to 'auto'.

The docstring for the load_model() function for all 3 model checkpoints was updated to reflect the changes.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)

## Testing

Tested loading each model setting device map to different modes - 'auto', 'cuda', 'cpu'. In a cloud environment passing the cases.

I have read the CLA Document and I sign the CLA.

