### PR TITLE
Pin lightning==2.6.1 to avoid compromised 2.6.2/2.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 dependencies = [
     "roboflow>=1.1.0",
     "dacite>=1.9.1",
-    "lightning>=2.4.0",
+    "lightning==2.6.1",
     "supervision>=0.26.0rc4",
     "requests>=2.31.0,<=2.32.3",
     "typer>=0.12.5",


### PR DESCRIPTION
## Summary
- Pin `lightning` to `==2.6.1` (was `>=2.4.0`) so a fresh install does not resolve to the malicious wheels on PyPI.

## Why
Lightning AI advisory **[GHSA-w37p-236h-pfx3](https://github.com/Lightning-AI/pytorch-lightning/security/advisories/GHSA-w37p-236h-pfx3)** (published 2026-04-30) confirms that `lightning` / `pytorch-lightning` **2.6.2** and **2.6.3** on PyPI were compromised. The wheels include a hidden `_runtime/` directory with a `start.py` downloader and an ~11 MB obfuscated `router_runtime.js` payload that auto-executes on `import lightning`, harvests credentials (GitHub/npm/PyPI tokens, cloud creds, env vars, SSH keys), and attempts to commit encoded data back to victim repos. See Socket's writeup: https://socket.dev/blog/lightning-pypi-package-compromised.

`2.6.1` (published 2026-01-30) is the last known clean release. The current spec `lightning>=2.4.0` is unbounded and would resolve to `2.6.3` on a fresh install — this PR forces resolvers to skip the malicious versions until upstream ships a clean replacement.

## Notes
- Hard pin is intentionally narrow until Lightning AI publishes a confirmed-clean 2.6.4+. Once that lands we can relax to a `>=` range again.
- maestro has no lockfile, so no `uv lock` / `poetry lock` regeneration is needed — the `pyproject.toml` change is sufficient.

## Test plan
- [ ] Confirm `pip install -e .` still resolves successfully
- [ ] Confirm CI passes